### PR TITLE
Update CI release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,10 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: martezr/ghaction-import-gpg@v2.1.1
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.8.1


### PR DESCRIPTION
This PR updates the Github action utilized to sign releases due to a breaking change in the existing Github action. The Github action is recommended by HashiCorp as a replacement (https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410).