### PR TITLE
Fix the default branch for the ansible integration resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+NOTES:
+
+* Fix the `morpheus_ansible_integration` resource to properly set the default branch for the integration.
+
+FEATURES:
+
+
 ## 0.6.0 (September 12, 2022)
 
 NOTES:

--- a/morpheus/resource_ansible_integration.go
+++ b/morpheus/resource_ansible_integration.go
@@ -162,6 +162,7 @@ func resourceAnsibleIntegrationCreate(ctx context.Context, d *schema.ResourceDat
 
 	config := make(map[string]interface{})
 	config["defaultBranch"] = d.Get("default_branch").(string)
+        config["ansibleDefaultBranch"] = d.Get("default_branch").(string)
 	config["cacheEnabled"] = d.Get("enable_git_caching").(bool)
 	config["ansiblePlaybooks"] = d.Get("playbooks_path").(string)
 	config["ansibleRoles"] = d.Get("roles_path").(string)
@@ -265,6 +266,7 @@ func resourceAnsibleIntegrationUpdate(ctx context.Context, d *schema.ResourceDat
 
 	config := make(map[string]interface{})
 	config["defaultBranch"] = d.Get("default_branch").(string)
+        config["ansibleDefaultBranch"] = d.Get("default_branch").(string)
 	config["cacheEnabled"] = d.Get("enable_git_caching").(bool)
 	config["ansiblePlaybooks"] = d.Get("playbooks_path").(string)
 	config["ansibleRoles"] = d.Get("roles_path").(string)


### PR DESCRIPTION
This PR fixes the issue with properly setting the default branch for the Ansible integration resource.