### PR TITLE
Suppress JSON whitespace changes

### DIFF
--- a/morpheus/diff_suppress_funcs.go
+++ b/morpheus/diff_suppress_funcs.go
@@ -1,0 +1,22 @@
+package morpheus
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func suppressEquivalentJsonDiffs(k, old, new string, d *schema.ResourceData) bool {
+	ob := bytes.NewBufferString("")
+	if err := json.Compact(ob, []byte(old)); err != nil {
+		return false
+	}
+
+	nb := bytes.NewBufferString("")
+	if err := json.Compact(nb, []byte(new)); err != nil {
+		return false
+	}
+
+	return jsonBytesEqual(ob.Bytes(), nb.Bytes())
+}

--- a/morpheus/resource_manual_option_list.go
+++ b/morpheus/resource_manual_option_list.go
@@ -43,9 +43,10 @@ func resourceManualOptionList() *schema.Resource {
 				Default:      "private",
 			},
 			"dataset": {
-				Type:        schema.TypeString,
-				Description: "The dataset for the manual option list",
-				Optional:    true,
+				Type:             schema.TypeString,
+				Description:      "The dataset for the manual option list",
+				Optional:         true,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 			"real_time": {
 				Type:        schema.TypeBool,

--- a/morpheus/util.go
+++ b/morpheus/util.go
@@ -1,0 +1,20 @@
+package morpheus
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+func jsonBytesEqual(b1, b2 []byte) bool {
+	var o1 interface{}
+	if err := json.Unmarshal(b1, &o1); err != nil {
+		return false
+	}
+
+	var o2 interface{}
+	if err := json.Unmarshal(b2, &o2); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(o1, o2)
+}


### PR DESCRIPTION
In the resource_manual_option_list, JSON whitespace shows up as changes. I've implemented the diff suppress function capability for the dataset so it ignores whitespace. This code came from https://github.com/huaweicloud/terraform-provider-huaweicloudstack.