### PR TITLE
Add assume role support to AWS cloud

### DIFF
--- a/docs/resources/aws_cloud.md
+++ b/docs/resources/aws_cloud.md
@@ -89,6 +89,7 @@ resource "morpheus_aws_cloud" "tf_example_aws_cloud" {
 - `guidance` (String) Whether to enable guidance recommendations on the cloud (manual, off)
 - `inventory` (String) Whether to import existing virtual machines (off, basic, full)
 - `location` (String) Optional location for the cloud
+- `role_arn` (String) The AWS IAM role ARN to assume for authentication
 - `secret_key` (String, Sensitive) The AWS secret key used for authentication
 - `tenant_id` (String) The id of the morpheus tenant the cloud is assigned to
 - `time_zone` (String) The time zone for the cloud

--- a/morpheus/resource_aws_cloud.go
+++ b/morpheus/resource_aws_cloud.go
@@ -111,6 +111,12 @@ func resourceAWSCloud() *schema.Resource {
 				},
 				RequiredWith: []string{"access_key"},
 			},
+			"role_arn": {
+				Type:        schema.TypeString,
+				Description: "The AWS IAM role ARN to assume for authentication",
+				Optional:    true,
+				Computed:    true,
+			},
 			/* AWAITING SDK SUPPORT
 			"use_host_iam_credentials": {
 				Description: "Whether to use the IAM profile associated with the Morpheus server or not",
@@ -217,6 +223,8 @@ func resourceAWSCloudCreate(ctx context.Context, d *schema.ResourceData, meta in
 		config["accessKey"] = d.Get("access_key").(string)
 		config["secretKey"] = d.Get("secret_key").(string)
 	}
+
+	config["stsAssumeRole"] = d.Get("role_arn").(string)
 
 	cloud["inventoryLevel"] = d.Get("inventory").(string)
 	config["isVpc"] = "true"
@@ -343,6 +351,7 @@ func resourceAWSCloudRead(ctx context.Context, d *schema.ResourceData, meta inte
 		d.Set("credential_id", cloud.Credential.ID)
 		d.Set("access_key", cloud.Config.AccessKey)
 		d.Set("secret_key", cloud.Config.SecretKeyHash)
+		d.Set("role_arn", cloud.Config.StsAssumeRole)
 		d.Set("inventory", cloud.InventoryLevel)
 		if cloud.Config.VPC == "" {
 			d.Set("vpc", "all")
@@ -398,6 +407,8 @@ func resourceAWSCloudUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		config["accessKey"] = d.Get("access_key").(string)
 		config["secretKey"] = d.Get("secret_key").(string)
 	}
+
+	config["stsAssumeRole"] = d.Get("role_arn").(string)
 
 	cloud["inventoryLevel"] = d.Get("inventory").(string)
 	config["isVpc"] = "true"


### PR DESCRIPTION
Added support for an optional `role_arn` attribute on the `aws_cloud` resource for specifying the AWS IAM role Morpheus should assume with STS for a cloud. 

Not much code was needed, but this is my first time working with go, so please pay extra heed in your review.

I ran integration tests locally with success.

Resolves #103 