### PR TITLE
`data_source_resource_pool.go` update to include ID

### DIFF
--- a/docs/data-sources/resource_pool.md
+++ b/docs/data-sources/resource_pool.md
@@ -27,11 +27,11 @@ data "morpheus_resource_pool" "morpheus_pool" {
 
 ### Optional
 
+- `id` (Number) The id of the resource pool
 - `name` (String) The name of the Morpheus resource pool.
 
 ### Read-Only
 
 - `active` (Boolean) Whether the resource pool is enabled or not
 - `description` (String) The description of the resource pool
-- `id` (String) The ID of this resource.
 - `type` (String) Optional code for use with policies

--- a/docs/resources/vsphere_instance.md
+++ b/docs/resources/vsphere_instance.md
@@ -22,7 +22,7 @@ data "morpheus_cloud" "morpheus_vsphere" {
 
 data "morpheus_resource_pool" "vsphere_resource_pool" {
   name     = "Morpheus-Cluster"
-  cloud_id = data.morpheus_cloud.vsphere.id
+  cloud_id = data.morpheus_cloud.morpheus_vsphere.id
 }
 
 data "morpheus_instance_type" "apache" {

--- a/morpheus/data_source_resource_pool.go
+++ b/morpheus/data_source_resource_pool.go
@@ -39,6 +39,11 @@ func dataSourceMorpheusResourcePool() *schema.Resource {
 				Description: "The description of the resource pool",
 				Computed:    true,
 			},
+			"id": {
+				Type:        schema.TypeString,
+				Description: "The id of the resource pool",
+				Computed:    true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
`id` was missing from the `morpheus\data_source_resource_pool.go` but included in documentation. 

Changes: 
- Added ID as argument
- Changed ID from string to number to match existing patterns
- Adjusted Error message when either ID or name is not provided

I would also note though that the implementation I found in `data_source_cloud.go` to be better. Currently, giving both name and ID will return a positive 200 with the information, so it is not broken. I would say though for consistency, I would go with `data_source_cloud.go` implementation. 

From `data_source_cloud.go`
```golang
Schema: map[string]*schema.Schema{
			"id": {
				Type:          schema.TypeInt,
				Optional:      true,
				ConflictsWith: []string{"name"},
				Computed:      true,
			},
			"name": {
				Type:          schema.TypeString,
				Description:   "The name of the Morpheus cloud",
				Optional:      true,
				ConflictsWith: []string{"id"},
			},
			"code": {
				Type:        schema.TypeString,
				Description: "Optional code for use with policies",
				Computed:    true,
			},
			"location": {
				Type:        schema.TypeString,
				Description: "Optional location for your cloud",
				Computed:    true,
			},
		},
```