### PR TITLE
updates appropriate resources to be recreated on manual deletion - fixes #164

### DIFF
--- a/morpheus/resource_active_directory_identity_source.go
+++ b/morpheus/resource_active_directory_identity_source.go
@@ -218,7 +218,9 @@ func resourceActiveDirectoryIdentitySourceRead(ctx context.Context, d *schema.Re
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ansible_integration.go
+++ b/morpheus/resource_ansible_integration.go
@@ -218,7 +218,9 @@ func resourceAnsibleIntegrationRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ansible_playbook_task.go
+++ b/morpheus/resource_ansible_playbook_task.go
@@ -193,7 +193,9 @@ func resourceAnsiblePlaybookTaskRead(ctx context.Context, d *schema.ResourceData
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ansible_tower_integration.go
+++ b/morpheus/resource_ansible_tower_integration.go
@@ -148,7 +148,9 @@ func resourceAnsibleTowerIntegrationRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ansible_tower_task.go
+++ b/morpheus/resource_ansible_tower_task.go
@@ -204,7 +204,9 @@ func resourceAnsibleTowerTaskRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_api_option_list.go
+++ b/morpheus/resource_api_option_list.go
@@ -143,7 +143,9 @@ func resourceApiOptionListRead(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_app_blueprint_catalog_item.go
+++ b/morpheus/resource_app_blueprint_catalog_item.go
@@ -235,7 +235,9 @@ func resourceAppBlueprintCatalogItemRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_arm_app_blueprint.go
+++ b/morpheus/resource_arm_app_blueprint.go
@@ -187,7 +187,9 @@ func resourceArmAppBlueprintRead(ctx context.Context, d *schema.ResourceData, me
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_arm_spec_template.go
+++ b/morpheus/resource_arm_spec_template.go
@@ -141,7 +141,9 @@ func resourceArmSpecTemplateRead(ctx context.Context, d *schema.ResourceData, me
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_backup_creation_policy.go
+++ b/morpheus/resource_backup_creation_policy.go
@@ -206,7 +206,9 @@ func resourceBackupCreationPolicyRead(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_backup_setting.go
+++ b/morpheus/resource_backup_setting.go
@@ -128,7 +128,9 @@ func resourceBackupSettingRead(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_boot_script.go
+++ b/morpheus/resource_boot_script.go
@@ -102,7 +102,9 @@ func resourceBootScriptRead(ctx context.Context, d *schema.ResourceData, meta in
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_budget_policy.go
+++ b/morpheus/resource_budget_policy.go
@@ -205,7 +205,9 @@ func resourceBudgetPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_checkbox_option_type.go
+++ b/morpheus/resource_checkbox_option_type.go
@@ -187,7 +187,9 @@ func resourceCheckboxOptionTypeRead(ctx context.Context, d *schema.ResourceData,
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_cloud_formation_app_blueprint.go
+++ b/morpheus/resource_cloud_formation_app_blueprint.go
@@ -200,7 +200,9 @@ func resourceCloudFormationAppBlueprintRead(ctx context.Context, d *schema.Resou
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_cloud_formation_spec_template.go
+++ b/morpheus/resource_cloud_formation_spec_template.go
@@ -173,7 +173,9 @@ func resourceCloudFormationSpecTemplateRead(ctx context.Context, d *schema.Resou
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_cluster_layout.go
+++ b/morpheus/resource_cluster_layout.go
@@ -322,7 +322,9 @@ func resourceClusterLayoutRead(ctx context.Context, d *schema.ResourceData, meta
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_cluster_package.go
+++ b/morpheus/resource_cluster_package.go
@@ -141,6 +141,7 @@ func resourceClusterPackageRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_cluster_resource_name_policy.go
+++ b/morpheus/resource_cluster_resource_name_policy.go
@@ -212,7 +212,9 @@ func resourceClusterResourceNamePolicyRead(ctx context.Context, d *schema.Resour
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_contact.go
+++ b/morpheus/resource_contact.go
@@ -103,7 +103,9 @@ func resourceContactRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_credential.go
+++ b/morpheus/resource_credential.go
@@ -249,6 +249,7 @@ func resourceCredentialRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_cypher_access_policy.go
+++ b/morpheus/resource_cypher_access_policy.go
@@ -203,7 +203,9 @@ func resourceCypherAccessPolicyRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_cypher_secret.go
+++ b/morpheus/resource_cypher_secret.go
@@ -105,6 +105,7 @@ func resourceCypherSecretRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_cypher_tfvars.go
+++ b/morpheus/resource_cypher_tfvars.go
@@ -105,6 +105,7 @@ func resourceCypherTFVarsRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_delayed_delete_policy.go
+++ b/morpheus/resource_delayed_delete_policy.go
@@ -194,7 +194,9 @@ func resourceDelayedDeletePolicyRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_delete_approval_policy.go
+++ b/morpheus/resource_delete_approval_policy.go
@@ -209,7 +209,9 @@ func resourceDeleteApprovalPolicyRead(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_docker_registry_integration.go
+++ b/morpheus/resource_docker_registry_integration.go
@@ -129,7 +129,9 @@ func resourceDockerRegistryIntegrationRead(ctx context.Context, d *schema.Resour
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_email_task.go
+++ b/morpheus/resource_email_task.go
@@ -222,7 +222,9 @@ func resourceEmailTaskRead(ctx context.Context, d *schema.ResourceData, meta int
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_execute_schedule.go
+++ b/morpheus/resource_execute_schedule.go
@@ -116,7 +116,9 @@ func resourceExecuteScheduleRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_file_template.go
+++ b/morpheus/resource_file_template.go
@@ -156,7 +156,9 @@ func resourceFileTemplateRead(ctx context.Context, d *schema.ResourceData, meta 
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_git_integration.go
+++ b/morpheus/resource_git_integration.go
@@ -176,7 +176,9 @@ func resourceGitIntegrationRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_groovy_script_task.go
+++ b/morpheus/resource_groovy_script_task.go
@@ -201,7 +201,9 @@ func resourceGroovyScriptTaskRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_group.go
+++ b/morpheus/resource_group.go
@@ -147,7 +147,9 @@ func resourceMorpheusGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_guidance_setting.go
+++ b/morpheus/resource_guidance_setting.go
@@ -163,7 +163,9 @@ func resourceGuidanceSettingRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_helm_app_blueprint.go
+++ b/morpheus/resource_helm_app_blueprint.go
@@ -149,7 +149,9 @@ func resourceHelmAppBlueprintRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_helm_spec_template.go
+++ b/morpheus/resource_helm_spec_template.go
@@ -143,7 +143,9 @@ func resourceHelmSpecTemplateRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_hidden_option_type.go
+++ b/morpheus/resource_hidden_option_type.go
@@ -175,7 +175,9 @@ func resourceHiddenOptionTypeRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_hostname_policy.go
+++ b/morpheus/resource_hostname_policy.go
@@ -199,7 +199,9 @@ func resourceHostNamePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_instance_catalog_item.go
+++ b/morpheus/resource_instance_catalog_item.go
@@ -202,7 +202,9 @@ func resourceInstanceCatalogItemRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_instance_layout.go
+++ b/morpheus/resource_instance_layout.go
@@ -256,7 +256,9 @@ func resourceInstanceLayoutRead(ctx context.Context, d *schema.ResourceData, met
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_instance_name_policy.go
+++ b/morpheus/resource_instance_name_policy.go
@@ -213,7 +213,9 @@ func resourceInstanceNamePolicyRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_instance_type.go
+++ b/morpheus/resource_instance_type.go
@@ -262,7 +262,9 @@ func resourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, meta 
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ipv4_ip_pool.go
+++ b/morpheus/resource_ipv4_ip_pool.go
@@ -110,7 +110,9 @@ func resourceIPv4IPPoolRead(ctx context.Context, d *schema.ResourceData, meta in
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_javascript_task.go
+++ b/morpheus/resource_javascript_task.go
@@ -172,7 +172,9 @@ func resourceJavaScriptTaskRead(ctx context.Context, d *schema.ResourceData, met
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_kubernetes_app_blueprint.go
+++ b/morpheus/resource_kubernetes_app_blueprint.go
@@ -188,7 +188,9 @@ func resourceKubernetesAppBlueprintRead(ctx context.Context, d *schema.ResourceD
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_kubernetes_spec_template.go
+++ b/morpheus/resource_kubernetes_spec_template.go
@@ -143,7 +143,9 @@ func resourceKubernetesSpecTemplateRead(ctx context.Context, d *schema.ResourceD
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_library_script_task.go
+++ b/morpheus/resource_library_script_task.go
@@ -195,6 +195,7 @@ func resourceLibraryScriptTaskRead(ctx context.Context, d *schema.ResourceData, 
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_library_template_task.go
+++ b/morpheus/resource_library_template_task.go
@@ -194,6 +194,7 @@ func resourceLibraryTemplateTaskRead(ctx context.Context, d *schema.ResourceData
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_license.go
+++ b/morpheus/resource_license.go
@@ -78,7 +78,9 @@ func resourceLicenseRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_manual_option_list.go
+++ b/morpheus/resource_manual_option_list.go
@@ -140,7 +140,9 @@ func resourceManualOptionListRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_containers_policy.go
+++ b/morpheus/resource_max_containers_policy.go
@@ -193,7 +193,9 @@ func resourceMaxContainersPolicyRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_cores_policy.go
+++ b/morpheus/resource_max_cores_policy.go
@@ -193,7 +193,9 @@ func resourceMaxCoresPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_hosts_policy.go
+++ b/morpheus/resource_max_hosts_policy.go
@@ -193,7 +193,9 @@ func resourceMaxHostsPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_memory_policy.go
+++ b/morpheus/resource_max_memory_policy.go
@@ -193,7 +193,9 @@ func resourceMaxMemoryPolicyRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_storage_policy.go.go
+++ b/morpheus/resource_max_storage_policy.go.go
@@ -193,7 +193,9 @@ func resourceMaxStoragePolicyRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_max_vms_policy.go
+++ b/morpheus/resource_max_vms_policy.go
@@ -193,7 +193,9 @@ func resourceMaxVmsPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_monitoring_setting.go
+++ b/morpheus/resource_monitoring_setting.go
@@ -241,7 +241,9 @@ func resourceMonitoringSettingRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_motd_policy.go
+++ b/morpheus/resource_motd_policy.go
@@ -148,7 +148,9 @@ func resourceMotdPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_nested_workflow_task.go
+++ b/morpheus/resource_nested_workflow_task.go
@@ -166,7 +166,9 @@ func resourceNestedWorkflowTaskRead(ctx context.Context, d *schema.ResourceData,
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_network_domain.go
+++ b/morpheus/resource_network_domain.go
@@ -148,7 +148,9 @@ func resourceNetworkDomainRead(ctx context.Context, d *schema.ResourceData, meta
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_network_quota_policy.go
+++ b/morpheus/resource_network_quota_policy.go
@@ -193,7 +193,9 @@ func resourceNetworkQuotaPolicyRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_node_type.go
+++ b/morpheus/resource_node_type.go
@@ -273,7 +273,9 @@ func resourceNodeTypeRead(ctx context.Context, d *schema.ResourceData, meta inte
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_number_option_type.go
+++ b/morpheus/resource_number_option_type.go
@@ -202,7 +202,9 @@ func resourceNumberOptionTypeRead(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_operational_workflow.go
+++ b/morpheus/resource_operational_workflow.go
@@ -162,7 +162,9 @@ func resourceOperationalWorkflowRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_password_option_type.go
+++ b/morpheus/resource_password_option_type.go
@@ -209,7 +209,9 @@ func resourcePasswordOptionTypeRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_power_schedule_policy.go
+++ b/morpheus/resource_power_schedule_policy.go
@@ -206,7 +206,9 @@ func resourcePowerSchedulePolicyRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_powershell_script_task.go
+++ b/morpheus/resource_powershell_script_task.go
@@ -267,7 +267,9 @@ func resourcePowerShellScriptTaskRead(ctx context.Context, d *schema.ResourceDat
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_preseed_script.go
+++ b/morpheus/resource_preseed_script.go
@@ -102,7 +102,9 @@ func resourcePreseedScriptRead(ctx context.Context, d *schema.ResourceData, meta
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_price.go
+++ b/morpheus/resource_price.go
@@ -230,7 +230,9 @@ func resourcePriceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_price_set.go
+++ b/morpheus/resource_price_set.go
@@ -156,7 +156,9 @@ func resourcePriceSetRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_provision_approval_policy.go
+++ b/morpheus/resource_provision_approval_policy.go
@@ -209,7 +209,9 @@ func resourceProvisionApprovalPolicyRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_provisioning_setting.go
+++ b/morpheus/resource_provisioning_setting.go
@@ -199,7 +199,9 @@ func resourceProvisioningSettingRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_provisioning_workflow.go
+++ b/morpheus/resource_provisioning_workflow.go
@@ -167,7 +167,9 @@ func resourceProvisioningWorkflowRead(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_puppet_integration.go
+++ b/morpheus/resource_puppet_integration.go
@@ -144,7 +144,9 @@ func resourcePuppetIntegrationRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_python_script_task.go
+++ b/morpheus/resource_python_script_task.go
@@ -224,7 +224,9 @@ func resourcePythonScriptTaskRead(ctx context.Context, d *schema.ResourceData, m
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_radio_list_option_type.go
+++ b/morpheus/resource_radio_list_option_type.go
@@ -207,7 +207,9 @@ func resourceRadioListOptionTypeRead(ctx context.Context, d *schema.ResourceData
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_resource_pool_group.go
+++ b/morpheus/resource_resource_pool_group.go
@@ -176,7 +176,9 @@ func resourceResourcePoolGroupRead(ctx context.Context, d *schema.ResourceData, 
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_rest_option_list.go
+++ b/morpheus/resource_rest_option_list.go
@@ -221,7 +221,9 @@ func resourceRestOptionListRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_restart_task.go
+++ b/morpheus/resource_restart_task.go
@@ -146,7 +146,9 @@ func resourceRestartTaskRead(ctx context.Context, d *schema.ResourceData, meta i
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_router_quota_policy.go
+++ b/morpheus/resource_router_quota_policy.go
@@ -193,7 +193,9 @@ func resourceRouterQuotaPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_ruby_script_task.go
+++ b/morpheus/resource_ruby_script_task.go
@@ -194,7 +194,9 @@ func resourceRubyScriptTaskRead(ctx context.Context, d *schema.ResourceData, met
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_saml_identity_source.go
+++ b/morpheus/resource_saml_identity_source.go
@@ -236,7 +236,9 @@ func resourceSAMLIdentitySourceRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_scale_threshold.go
+++ b/morpheus/resource_scale_threshold.go
@@ -175,7 +175,9 @@ func resourceScaleThresholdRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_script_template.go
+++ b/morpheus/resource_script_template.go
@@ -144,7 +144,9 @@ func resourceScriptTemplateRead(ctx context.Context, d *schema.ResourceData, met
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_security_package.go
+++ b/morpheus/resource_security_package.go
@@ -124,7 +124,9 @@ func resourceSecurityPackageRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_select_list_option_type.go
+++ b/morpheus/resource_select_list_option_type.go
@@ -197,7 +197,9 @@ func resourceSelectListOptionTypeRead(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_service_plan.go
+++ b/morpheus/resource_service_plan.go
@@ -334,7 +334,9 @@ func resourceServicePlanRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_servicenow_integration.go
+++ b/morpheus/resource_servicenow_integration.go
@@ -192,7 +192,9 @@ func resourceServiceNowIntegrationRead(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_shell_script_task.go
+++ b/morpheus/resource_shell_script_task.go
@@ -298,7 +298,9 @@ func resourceShellScriptTaskRead(ctx context.Context, d *schema.ResourceData, me
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_tag_policy.go
+++ b/morpheus/resource_tag_policy.go
@@ -196,7 +196,9 @@ func resourceTagPolicyRead(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_task_job.go
+++ b/morpheus/resource_task_job.go
@@ -224,6 +224,7 @@ func resourceTaskJobRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
+			log.Printf("Forcing recreation of resource")
 			d.SetId("")
 			return diags
 		} else {

--- a/morpheus/resource_tenant.go
+++ b/morpheus/resource_tenant.go
@@ -147,7 +147,9 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_terraform_app_blueprint.go
+++ b/morpheus/resource_terraform_app_blueprint.go
@@ -220,7 +220,9 @@ func resourceTerraformAppBlueprintRead(ctx context.Context, d *schema.ResourceDa
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_terraform_spec_template.go
+++ b/morpheus/resource_terraform_spec_template.go
@@ -142,7 +142,9 @@ func resourceTerraformSpecTemplateRead(ctx context.Context, d *schema.ResourceDa
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_text_option_type.go
+++ b/morpheus/resource_text_option_type.go
@@ -209,7 +209,9 @@ func resourceTextOptionTypeRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_textarea_option_type.go
+++ b/morpheus/resource_textarea_option_type.go
@@ -220,7 +220,9 @@ func resourceTextAreaOptionTypeRead(ctx context.Context, d *schema.ResourceData,
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_typeahead_option_type.go
+++ b/morpheus/resource_typeahead_option_type.go
@@ -228,7 +228,9 @@ func resourceTypeAheadOptionTypeRead(ctx context.Context, d *schema.ResourceData
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_user_creation_policy.go
+++ b/morpheus/resource_user_creation_policy.go
@@ -206,7 +206,9 @@ func resourceUserCreationPolicyRead(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_user_group_creation_policy.go
+++ b/morpheus/resource_user_group_creation_policy.go
@@ -195,7 +195,9 @@ func resourceUserGroupCreationPolicyRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_user_role.go
+++ b/morpheus/resource_user_role.go
@@ -146,7 +146,9 @@ func resourceUserRoleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_vro_integration.go
+++ b/morpheus/resource_vro_integration.go
@@ -148,7 +148,9 @@ func resourceVrealizeOrchestratorIntegrationRead(ctx context.Context, d *schema.
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_vro_task.go
+++ b/morpheus/resource_vro_task.go
@@ -183,7 +183,9 @@ func resourceVrealizeOrchestratorTaskRead(ctx context.Context, d *schema.Resourc
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_vsphere_instance.go
+++ b/morpheus/resource_vsphere_instance.go
@@ -484,7 +484,9 @@ func resourceVsphereInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_wiki_page.go
+++ b/morpheus/resource_wiki_page.go
@@ -107,7 +107,9 @@ func resourceWikiPageRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_workflow_catalog_item.go
+++ b/morpheus/resource_workflow_catalog_item.go
@@ -233,7 +233,9 @@ func resourceWorkflowCatalogItemRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_workflow_job.go
+++ b/morpheus/resource_workflow_job.go
@@ -230,7 +230,9 @@ func resourceWorkflowJobRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_workflow_policy.go
+++ b/morpheus/resource_workflow_policy.go
@@ -195,7 +195,9 @@ func resourceWorkflowPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)

--- a/morpheus/resource_write_attributes_task.go
+++ b/morpheus/resource_write_attributes_task.go
@@ -163,7 +163,9 @@ func resourceWriteAttributesTaskRead(ctx context.Context, d *schema.ResourceData
 		// 404 is ok?
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf("API 404: %s - %s", resp, err)
-			return diag.FromErr(err)
+			log.Printf("Forcing recreation of resource")
+			d.SetId("")
+			return diags
 		} else {
 			log.Printf("API FAILURE: %s - %s", resp, err)
 			return diag.FromErr(err)


### PR DESCRIPTION
Amends the resource response when error is 404 which typically indicates resource cannot be found,  so has been deleted.

No changes to made to these resources for the moment, which had a different signature pattern, and I've not had opportunity to review why: 

``` 
 resource_aws_cloud
 resource_azure_cloud
 resource_environment
 resource_key_pairs
 resource_standard_cloud
 resource_vsphere_cloud
 resource_vsphere_cloud_datastore_configuration
```