### PR TITLE
Allow tracing of http requests/responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.7
 toolchain go1.23.6
 
 require (
-	github.com/gomorpheus/morpheus-go-sdk v0.5.1
+	github.com/gomorpheus/morpheus-go-sdk v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/gomorpheus/morpheus-go-sdk v0.5.1 h1:/YuXEkbcspOohNUZk3CL8vFo16ivc7iHPhfSY1KlGzI=
 github.com/gomorpheus/morpheus-go-sdk v0.5.1/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
+github.com/gomorpheus/morpheus-go-sdk v0.5.2 h1:E8VM8L4fghpVVMf1IuZkXZhCZij1Hol9ceQqUWYlACM=
+github.com/gomorpheus/morpheus-go-sdk v0.5.2/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/morpheus/config.go
+++ b/morpheus/config.go
@@ -2,9 +2,11 @@ package morpheus
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/gomorpheus/morpheus-go-sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 )
 
 // Config is the configuration structure used to instantiate the Morpheus
@@ -26,8 +28,11 @@ type Config struct {
 }
 
 func (c *Config) Client() (*morpheus.Client, diag.Diagnostics) {
+
+	debug := logging.IsDebugOrHigher() && os.Getenv("MORPHEUS_API_HTTPTRACE") == "true"
+
 	if c.client == nil {
-		client := morpheus.NewClient(c.Url)
+		client := morpheus.NewClient(c.Url, morpheus.WithDebug(debug))
 		// should validate url here too, and maybe ping it
 		// logging with access token or username and password?
 		if c.Username != "" {


### PR DESCRIPTION
Allow developers to "see" what the provider is sending over the wire
in terms of morpheus API calls.

For this to work you need to set both:

```
export TF_LOG=DEBUG (or TF_LOG=TRACE)
export MORPHEUS_API_HTTPTRACE=true
```

We require `MORPHEUS_API_HTTPTRACE` in addition to the TF_LOG variable so that
http tracing (which may contain sensitive information) is not enabled when standard
terraform debugging is enabled.