### PR TITLE
Implement cluster worker node count update for MKS VSphere

### DIFF
--- a/docs/resources/vsphere_mks_cluster.md
+++ b/docs/resources/vsphere_mks_cluster.md
@@ -9,6 +9,11 @@ description: |-
 
 Provides an Morpheus Kubernetes Service (MKS) cluster on VMware vSphere resource
 
+## Notes
+
+### What to do if worker nodes fail to provision
+Sometimes updating the number of worker nodes may fail unexpectedly and the new worker nodes will fail to provision. If this happens, manually delete the new worker nodes either through the Morpheus UI or using the [Morpheus CLI] (https://clidocs.morpheusdata.com/), and retry the `terraform apply`.
+
 ## Example Usage
 
 ```terraform
@@ -62,16 +67,16 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
   cluster_layout_id       = 244
   pod_cidr                = "172.20.0.0/16"
   service_cidr            = "172.30.0.0/16"
-  workflow_id             = data.morpheus_workflow.example_workflow
+  workflow_id             = data.morpheus_workflow.example_workflow.id
   api_proxy_id            = 1
   cluster_repo_account_id = 1
 
   master_node_pool {
     plan_id          = data.morpheus_plan.master_nodes
-    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool
+    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool.id
 
     network_interface {
-      network_id = data.morpheus_network.vm_network
+      network_id = data.morpheus_network.vm_network.id
     }
 
     storage_volume {
@@ -79,7 +84,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 30
       name         = "root"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     tags = {
@@ -90,14 +95,14 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
   worker_node_pool {
     count            = 3
     plan_id          = data.morpheus_plan.worker_nodes
-    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool
+    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool.id
 
     network_interface {
-      network_id = data.morpheus_network.vm_network
+      network_id = data.morpheus_network.vm_network.id
     }
 
     network_interface {
-      network_id = data.morpheus_network.internal_network
+      network_id = data.morpheus_network.internal_network.id
     }
 
     storage_volume {
@@ -105,7 +110,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 30
       name         = "root"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     storage_volume {
@@ -113,7 +118,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 15
       name         = "data"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     tags = {
@@ -208,11 +213,11 @@ Optional:
 
 Required:
 
-- `count` (Number) The number of worker nodes
 - `plan_id` (Number) The ID of the service plan associated with the worker nodes in the cluster
 
 Optional:
 
+- `count` (Number) The number of worker nodes
 - `network_interface` (Block List) The network interfaces to create for the cluster worker nodes (see [below for nested schema](#nestedblock--worker_node_pool--network_interface))
 - `resource_pool_id` (Number) The ID of the resource pool to provision the cluster worker nodes to
 - `storage_volume` (Block List) The storage volumes to create for the cluster worker nodes (see [below for nested schema](#nestedblock--worker_node_pool--storage_volume))

--- a/examples/resources/morpheus_vsphere_mks_cluster/resource.tf
+++ b/examples/resources/morpheus_vsphere_mks_cluster/resource.tf
@@ -48,16 +48,16 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
   cluster_layout_id       = 244
   pod_cidr                = "172.20.0.0/16"
   service_cidr            = "172.30.0.0/16"
-  workflow_id             = data.morpheus_workflow.example_workflow
+  workflow_id             = data.morpheus_workflow.example_workflow.id
   api_proxy_id            = 1
   cluster_repo_account_id = 1
 
   master_node_pool {
     plan_id          = data.morpheus_plan.master_nodes
-    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool
+    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool.id
 
     network_interface {
-      network_id = data.morpheus_network.vm_network
+      network_id = data.morpheus_network.vm_network.id
     }
 
     storage_volume {
@@ -65,7 +65,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 30
       name         = "root"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     tags = {
@@ -76,14 +76,14 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
   worker_node_pool {
     count            = 3
     plan_id          = data.morpheus_plan.worker_nodes
-    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool
+    resource_pool_id = data.morpheus_resource_pool.vsphere_resource_pool.id
 
     network_interface {
-      network_id = data.morpheus_network.vm_network
+      network_id = data.morpheus_network.vm_network.id
     }
 
     network_interface {
-      network_id = data.morpheus_network.internal_network
+      network_id = data.morpheus_network.internal_network.id
     }
 
     storage_volume {
@@ -91,7 +91,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 30
       name         = "root"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     storage_volume {
@@ -99,7 +99,7 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
       size         = 15
       name         = "data"
       storage_type = 1
-      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore
+      datastore_id = data.morpheus_cloud_datastore.vsphere_datastore.id
     }
 
     tags = {
@@ -107,3 +107,4 @@ resource "morpheus_vsphere_mks_cluster" "tf_example_vsphere_instance" {
     }
   }
 }
+

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"time"
 
@@ -400,6 +401,11 @@ func getClusterWorkers(client *morpheus.Client, clusterId int64) ([]morpheus.Clu
 	if err := json.Unmarshal(resp.Body, &workerResp); err != nil {
 		return nil, err
 	}
+
+	// Sort the workers by date created to avoid naming problems i.e. worker-1-1
+	sort.Slice(*workerResp.Workers, func(i, j int) bool {
+		return (*workerResp.Workers)[i].DateCreated.Unix() < (*workerResp.Workers)[j].DateCreated.Unix()
+	})
 
 	return *workerResp.Workers, nil
 }

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -234,7 +234,7 @@ func resourceVsphereMKSCluster() *schema.Resource {
 									},
 									"datastore_id": {
 										Description: "The ID of the datastore",
-										Type:        schema.TypeString,
+										Type:        schema.TypeInt,
 										ForceNew:    true,
 										Required:    true,
 									},

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -688,14 +688,17 @@ func resourceVsphereMKSClusterUpdate(ctx context.Context, d *schema.ResourceData
 		if !ok {
 			return diag.Errorf("failed to get old worker_node_pool.count")
 		}
+
 		oldCount, ok := oldValues["count"].(int)
 		if !ok {
 			return diag.Errorf("failed to get old worker_node_pool.count as int")
 		}
+
 		newValues, ok := n.([]interface{})[0].(map[string]interface{})
 		if !ok {
 			return diag.Errorf("failed to get new worker_node_pool.count")
 		}
+
 		newCount, ok := newValues["count"].(int)
 		if !ok {
 			return diag.Errorf("failed to get new worker_node_pool.count as int")
@@ -709,7 +712,6 @@ func resourceVsphereMKSClusterUpdate(ctx context.Context, d *schema.ResourceData
 				if err != nil {
 					return diag.Errorf("error adding cluster worker node(s): %s", err)
 				}
-
 			} else {
 				// Make countDelta positive to pass to doClusterWorkerDelete
 				countDelta = -countDelta
@@ -719,7 +721,6 @@ func resourceVsphereMKSClusterUpdate(ctx context.Context, d *schema.ResourceData
 				}
 			}
 		}
-
 	}
 
 	clusterPayload := map[string]interface{}{}

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -379,7 +379,17 @@ func getClusterWorkers(client *morpheus.Client, clusterId int64) (*[]morpheus.Cl
 		return nil, err
 	}
 
-	return workerResp.Workers, nil
+	// Skip deprovisioning workers
+	var workers []morpheus.ClusterWorker
+	for _, worker := range *workerResp.Workers {
+		if worker.Status == "deprovisioning" {
+			continue
+		}
+
+		workers = append(workers, worker)
+	}
+
+	return &workers, nil
 }
 
 func resourceVsphereMKSClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	minimumMKSWorkerNodes = 3
+	pollSleepSeconds      = 10
 
 	statusCancelled      = "cancelled"
 	statusDenied         = "denied"
@@ -747,7 +748,7 @@ func doClusterWorkerAdd(client *morpheus.Client, clusterId int64, nodeCount int,
 
 	for {
 		log.Printf("Waiting for all cluster worker nodes to be provisioned...")
-		time.Sleep(30 * time.Second)
+		time.Sleep(pollSleepSeconds * time.Second)
 
 		workers, err := getClusterWorkers(client, clusterId)
 		if err != nil {
@@ -787,7 +788,7 @@ func doClusterWorkerDelete(client *morpheus.Client, clusterId int64, nodeCount i
 
 	for {
 		log.Printf("Waiting for cluster worker nodes to be deprovisioned...")
-		time.Sleep(30 * time.Second)
+		time.Sleep(pollSleepSeconds * time.Second)
 
 		workers, err := getClusterWorkers(client, clusterId)
 		if err != nil {

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -711,7 +711,7 @@ func doClusterWorkerDelete(client *morpheus.Client, clusterId int64, nodeCount i
 		return err
 	}
 
-	deleteWorkers := (*workers)[:nodeCount]
+	deleteWorkers := (*workers)[len(*workers)+nodeCount:]
 	for _, worker := range deleteWorkers {
 		resp, err := client.DeleteClusterWorker(clusterId, worker.ID, &morpheus.Request{})
 		if err != nil {

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -581,7 +581,6 @@ func resourceVsphereMKSClusterRead(ctx context.Context, d *schema.ResourceData, 
 			return diag.FromErr(err)
 		}
 	}
-	log.Printf("API RESPONSE: %s", resp)
 
 	// store resource data
 	result := resp.Result.(*morpheus.GetClusterResult)
@@ -614,13 +613,13 @@ func resourceVsphereMKSClusterRead(ctx context.Context, d *schema.ResourceData, 
 
 	var volumes []map[string]interface{}
 	for _, v := range worker.Volumes {
-		log.Printf("VOLUME: %+v", v)
+		sizeGB := v.MaxStorage / (1 << 30)
 		volume := map[string]interface{}{
 			"root":         v.RootVolume,
 			"name":         v.Name,
 			"datastore_id": v.DatastoreId,
-			"storage_type": v.StorageType,
-			"size":         v.Size,
+			"storage_type": v.TypeId,
+			"size":         sizeGB,
 		}
 		volumes = append(volumes, volume)
 	}

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -234,7 +234,7 @@ func resourceVsphereMKSCluster() *schema.Resource {
 									},
 									"datastore_id": {
 										Description: "The ID of the datastore",
-										Type:        schema.TypeInt,
+										Type:        schema.TypeString,
 										ForceNew:    true,
 										Required:    true,
 									},

--- a/morpheus/resource_vsphere_mks_cluster.go
+++ b/morpheus/resource_vsphere_mks_cluster.go
@@ -624,13 +624,22 @@ func resourceVsphereMKSClusterRead(ctx context.Context, d *schema.ResourceData, 
 		volumes = append(volumes, volume)
 	}
 
+	var networks []map[string]interface{}
+	for _, v := range worker.Interfaces {
+		network := map[string]interface{}{
+			"network_id": v.Network.ID,
+		}
+		networks = append(networks, network)
+	}
+
 	workerNodePool := []interface{}{
 		map[string]interface{}{
-			"count":            len(*workers),
-			"plan_id":          worker.Plan.ID,
-			"resource_pool_id": worker.ResourcePoolId,
-			"tags":             tags,
-			"storage_volume":   volumes,
+			"count":             len(*workers),
+			"plan_id":           worker.Plan.ID,
+			"resource_pool_id":  worker.ResourcePoolId,
+			"tags":              tags,
+			"storage_volume":    volumes,
+			"network_interface": networks,
 		},
 	}
 


### PR DESCRIPTION
This PR contains a number of changes which ultimately allow for a user to add or remove worker nodes using the Terraform provider with an MKS VSphere cluster.

Updating the `count` value of the `worker_node_pool` field will perform scaling up/down of the number of worker nodes.
The cluster must have a minimum of 3 worker nodes, which is also the default value if `count` is not specified.

Documentation around these changes has also been updated.

PCCP-156
PCCP-157
PCCP-179
