### PR TITLE
Run go mod tidy to fix go sdk import

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gomorpheus/morpheus-go-sdk v0.5.1 h1:/YuXEkbcspOohNUZk3CL8vFo16ivc7iHPhfSY1KlGzI=
-github.com/gomorpheus/morpheus-go-sdk v0.5.1/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
 github.com/gomorpheus/morpheus-go-sdk v0.5.2 h1:E8VM8L4fghpVVMf1IuZkXZhCZij1Hol9ceQqUWYlACM=
 github.com/gomorpheus/morpheus-go-sdk v0.5.2/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
The go.sum file seemed to have the wrong version of the Go SDK. This just runs `go mod tidy` to fix the import.