### PR TITLE
Fix Go SDK import in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.7
 toolchain go1.23.6
 
 require (
-	github.com/gomorpheus/morpheus-go-sdk v0.5.2
+	github.com/gomorpheus/morpheus-go-sdk v0.5.3
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gomorpheus/morpheus-go-sdk v0.5.2 h1:E8VM8L4fghpVVMf1IuZkXZhCZij1Hol9ceQqUWYlACM=
-github.com/gomorpheus/morpheus-go-sdk v0.5.2/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
+github.com/gomorpheus/morpheus-go-sdk v0.5.3 h1:2boLae5iKAIWctCiuaLCtbYSNdNNYz4ztshv2rUF05g=
+github.com/gomorpheus/morpheus-go-sdk v0.5.3/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
Updates the go mod file to use the correct, most recent release of the Go SDK.