### PR TITLE
Add connection_info to morpheus_vsphere_instance

### DIFF
--- a/docs/resources/vsphere_instance.md
+++ b/docs/resources/vsphere_instance.md
@@ -89,6 +89,7 @@ resource "morpheus_vsphere_instance" "tf_example_vsphere_instance" {
 ### Optional
 
 - `asset_tag` (String) The asset tag associated with the instance
+- `connection_info` (Block List) Connection information for the instance, a list - this is returned by the API and not set by the user (see [below for nested schema](#nestedblock--connection_info))
 - `create_user` (Boolean) Whether to create a user account on the instance that is associated with the provisioning user account
 - `custom_options` (Map of String) Custom options to pass to the instance
 - `description` (String) The user friendly description of the instance
@@ -114,6 +115,16 @@ resource "morpheus_vsphere_instance" "tf_example_vsphere_instance" {
 ### Read-Only
 
 - `id` (String) The ID of the instance
+
+<a id="nestedblock--connection_info"></a>
+### Nested Schema for `connection_info`
+
+Optional:
+
+- `ip` (String) The IP address to connect to
+- `name` (String) The name of the connection protocol
+- `port` (Number) The port to connect to
+
 
 <a id="nestedblock--evar"></a>
 ### Nested Schema for `evar`


### PR DESCRIPTION
Some customers want to get the IP address of a created instance for use as inventory for Ansible (for example).  The API spec includes a "connection_info" list which from testing is populated with the IP address and port to be used in connecting to a network interface.  In this PR we add "connection_info" to the Schema for morpheus_vsphere_instance and populate it with values from the reponse to the POST request.

We also add the interface information returned from the POST to the state-file.