### PR TITLE
Allow automatic selection of Datastore (and other changes)

### DIFF
--- a/docs/resources/vsphere_instance.md
+++ b/docs/resources/vsphere_instance.md
@@ -155,7 +155,8 @@ Optional:
 
 Optional:
 
-- `datastore_id` (Number) The ID of the datastore
+- `datastore_auto_selection` (String) Whether to automatically select the datastore, values can be 'auto' or 'autoCluster', specify this or datastore_id
+- `datastore_id` (Number) The ID of the datastore, specify this or datastore_auto_selection
 - `name` (String) The name/type of the LV being created
 - `root` (Boolean) Whether the volume is the root volume of the instance
 - `size` (Number) The size of the LV being created

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.23.6
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gomorpheus/morpheus-go-sdk v0.5.3
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.21.0


### PR DESCRIPTION
There are a few changes to morpheus_vsphere_instance in this PR:
- we add a new "volumes" attribute - datastore_auto_selection - which is a string with two possible values, "auto" and "autoCluster"
- this new attribute can only be set when datastore_id is not set
- to enforce the above we've had to write a CustomizeDiff function called volumesCustomizeDiff since the standard "conflicts_with" doesn't work for lists or sets
- while testing we noticed that a new instance creation was being triggered if "instance_type_code" wasn't set in the resource block
- to fix this we:
  - removed "ForceNew" from "instance_type_code" and "instance_type_id"
  - this means that a change will trigger an update, which will be a no-op since the update logic doesn't handle changes
  - to check for actual changes to either "instance_type_code" or "instance_type_id" made by the user we add a customdiff ForceNewIfChange that checks for non-zero values of either in the resource block
- modified a few input attribute value checks in the morpheus_vsphere_instance to also check that the attribute is not the zero value, since SDK v2.0 doesn't have real null values