### PR TITLE
Only set one of instance_type_code or instance_type_id in state-file

### DIFF
--- a/morpheus/resource_vsphere_instance.go
+++ b/morpheus/resource_vsphere_instance.go
@@ -609,13 +609,23 @@ func resourceVsphereInstanceRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("Instance not found in response data.") // should not happen
 	}
 
+	// Special logic for "instance_type_id" and "instance_type_code".
+	// Only one of these will have been specified by the user.  We need to figure out which it is
+	// and store that value in the State.
+	if d.HasChange("instance_type_code") {
+		_, newVal := d.GetChange("instance_type_code")
+		d.Set("instance_type_code", newVal.(string))
+	}
+	if d.HasChange("instance_type_id") {
+		_, newVal := d.GetChange("instance_type_id")
+		d.Set("instance_type_id", newVal.(int64))
+	}
+
 	d.SetId(int64ToString(instance.ID))
 	d.Set("name", instance.Name)
 	d.Set("description", instance.Description)
 	d.Set("cloud_id", instance.Cloud.ID)
 	d.Set("group_id", instance.Group.ID)
-	d.Set("instance_type_id", instance.InstanceType.ID)
-	d.Set("instance_type_code", instance.InstanceType.Code)
 	d.Set("instance_layout_id", instance.Layout.ID)
 	d.Set("plan_id", instance.Plan.ID)
 	d.Set("resource_pool_id", instance.Config["resourcePoolId"])


### PR DESCRIPTION
We introduced a bug in v0.13.1 whereby we only allowed the user to set one of instance_type_code or instance_type_id in the config for morpheus_vsphere_instance but we stored the value of both in the state-file.  To fix this in this PR we:
- add logic to morpheus_vsphere_instance to only set the value of instance_type_code in the state-file if there is a change
- add logic to do the same with instance_type_id The logic is added to the read method.

This code will repair the bug in existing state-files and ensure that the bug will not reoccur.  This means that on the first run of apply with where a morpheus_vsphere_instance is present in the state-file an update will be performed which won't change the instance but which will fix the state-file (on the read).  Subsequent runs of apply will do nothing.

We already ensure that a recreate will be triggered if either instance_type_code or instance_type_id are actually changed by the user through the use of CusomizeDiff functions.