### PR TITLE
Fix int64 bug in morpheus_vsphere_instance

### DIFF
--- a/morpheus/resource_vsphere_instance.go
+++ b/morpheus/resource_vsphere_instance.go
@@ -618,7 +618,7 @@ func resourceVsphereInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	if d.HasChange("instance_type_id") {
 		_, newVal := d.GetChange("instance_type_id")
-		d.Set("instance_type_id", newVal.(int64))
+		d.Set("instance_type_id", newVal.(int))
 	}
 
 	d.SetId(int64ToString(instance.ID))


### PR DESCRIPTION
We were incorrectly asserting that instance_type_id as specified by the user is int64.  It is actually int.