### PR TITLE
Add SSL cert checking

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,13 @@ The Morpheus provider is used to interact with the resources supported by [Morph
 
 Use the navigation to the left to read about the available resources.
 
+!> Previous versions of this provider had Morpheus SSL cert checking disabled with no
+option to enable it. We've added the option to enable SSL cert checking by
+setting the `secure` argument to `true` or by setting the `MORPHEUS_API_SECURE` environment
+variable to `true`. The default value is `false` to maintain backwards compatibility.
+We recommend enabling SSL cert checking in production environments.  A warning message will
+be displayed if SSL cert checking is disabled.
+
 ## Authentication
 
 The Morpheus provider supports a number of different methods for authenticating to Morpheus:
@@ -48,5 +55,6 @@ provider "morpheus" {
 
 - `access_token` (String, Sensitive) Access Token of Morpheus user. This can be used instead of authenticating with Username and Password.
 - `password` (String, Sensitive) Password of Morpheus user for authentication
+- `secure` (Boolean) Allow the provider to enable certificate verification. If omitted, default value is "false".
 - `tenant_subdomain` (String) The tenant subdomain used for authentication
 - `username` (String) Username of Morpheus user for authentication

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.2
 
 require (
-	github.com/gomorpheus/morpheus-go-sdk v0.5.3
+	github.com/gomorpheus/morpheus-go-sdk v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/gomorpheus/morpheus-go-sdk v0.5.3 h1:2boLae5iKAIWctCiuaLCtbYSNdNNYz4ztshv2rUF05g=
 github.com/gomorpheus/morpheus-go-sdk v0.5.3/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
+github.com/gomorpheus/morpheus-go-sdk v0.6.0 h1:u6qJnMYExAJKapLbMXXalFtzuTiUP1dkH80YQfK2Ya4=
+github.com/gomorpheus/morpheus-go-sdk v0.6.0/go.mod h1:xVE9JlpQ6qxTr7mXad5MlzxLKvavIJ/cHcN1up7RikY=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/morpheus/provider.go
+++ b/morpheus/provider.go
@@ -50,6 +50,14 @@ func Provider() *schema.Provider {
 				DefaultFunc:   schema.EnvDefaultFunc("MORPHEUS_API_PASSWORD", nil),
 				ConflictsWith: []string{"access_token"},
 			},
+
+			// defaults to false
+			"secure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Allow the provider to enable certificate verification. If omitted, default value is "false".`,
+				DefaultFunc: schema.EnvDefaultFunc("MORPHEUS_API_SECURE", false),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -256,7 +264,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		TenantSubdomain: d.Get("tenant_subdomain").(string),
 		Username:        d.Get("username").(string),
 		Password:        d.Get("password").(string),
-		//Insecure:                d.Get("insecure").(bool), //.(bool),
+		Insecure:        !d.Get("secure").(bool), //.(bool),
 	}
+
 	return config.Client()
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,6 +11,13 @@ The Morpheus provider is used to interact with the resources supported by [Morph
 
 Use the navigation to the left to read about the available resources.
 
+!> Previous versions of this provider had Morpheus SSL cert checking disabled with no
+option to enable it. We've added the option to enable SSL cert checking by
+setting the `secure` argument to `true` or by setting the `MORPHEUS_API_SECURE` environment
+variable to `true`. The default value is `false` to maintain backwards compatibility.
+We recommend enabling SSL cert checking in production environments.  A warning message will
+be displayed if SSL cert checking is disabled.
+
 ## Authentication
 
 The Morpheus provider supports a number of different methods for authenticating to Morpheus:


### PR DESCRIPTION
In this PR we add the ability to enable Morpheus API SSL cert checking. For backwards compatibility we disable checking by default.  We generate a warning on each terraform execution (plan, apply, delete) if cert checking is disabled informing users how to enable it.  We generate an error message if cert checking fails informing users that they should fix their cert problems and if they need to providing instructions on how to disable cert checking.

This is based on a PR of Naoises.

We've added a Warning to the docs landing page regarding this new functionality.